### PR TITLE
updated line.cr to fit with the new default value syntax

### DIFF
--- a/src/termbox/line.cr
+++ b/src/termbox/line.cr
@@ -4,7 +4,7 @@ module Termbox
   class Line < Termbox::Element
     getter :cell, :size, :is_vertical
 
-    def initialize(@cell : Cell, @size : Int, @is_vertical = true : Bool)
+    def initialize(@cell : Cell, @size : Int, @is_vertical : Bool = true)
     end
 
     def render : Array(Cell)


### PR DESCRIPTION
From the 0.14.0 changelog:

> **(breaking change)** The syntax of a method argument with a default value and a type restriction is now `def foo(arg : Type = default_value)`.
