### PR TITLE
Update for Crystal 0.20.0

### DIFF
--- a/examples/input.cr
+++ b/examples/input.cr
@@ -11,7 +11,7 @@ w.set_input_mode(INPUT_ESC | INPUT_MOUSE)
 # Use 256 color mode
 w.set_output_mode(OUTPUT_256)
 # Use red foreground, periwinkle background
-w.set_primary_colors(196, 189)
+w.set_primary_colors(196_u16, 189_u16)
 # Reset things
 w.clear()
 

--- a/examples/simple.cr
+++ b/examples/simple.cr
@@ -8,7 +8,7 @@ w = Window.new
 # Use 256 color mode
 w.set_output_mode(OUTPUT_256)
 # Use red foreground, periwinkle background
-w.set_primary_colors(196, 189)
+w.set_primary_colors(196_u16, 189_u16)
 # Reset things
 w.clear()
 
@@ -39,7 +39,7 @@ w << Border.new(Position.new(38, 5), 15, 6, "solid")
 
 contain = Container.new(Position.new(54, 4), 15, 6)
   contain << Border.new(contain, '@')
-  contain << Cell.new('A', Position.new(2, 2), 231, 82)
+  contain << Cell.new('A', Position.new(2, 2), 231_u16, 82_u16)
   w << contain
 
 # Render the screen
@@ -50,7 +50,7 @@ sleep(1)
 
 # Write 0 - 9 again on 6th row, clearing 5th row as we go
 (0..9).each do |i|
-  w << Cell.new(i.to_s.char_at(0), Position.new(5 + i, 6), 56, 190)
+  w << Cell.new(i.to_s.char_at(0), Position.new(5 + i, 6), 56_u16, 190_u16)
   w.clear_cell(Position.new(5 + i, 5))
   # Put cursor after this cell
   w.cursor(Position.new(6 + i, 6))

--- a/src/termbox/border.cr
+++ b/src/termbox/border.cr
@@ -18,7 +18,7 @@ module Termbox
     end
 
     # For special-mode borders (normal, double, solid, cloth_low, cloth_med, cloth_high, dotted)
-    def initialize(pivot : Position, width : Int, height : Int, mode : String)
+    def initialize(pivot : Position, width : Int32, height : Int32, mode : String)
       # Decide on border character given mode
       # For normal/double/char modes, just use X (no use)
       case mode
@@ -40,17 +40,17 @@ module Termbox
     end
 
     # Normal mode
-    def initialize(pivot : Position, width : Int, height : Int)
+    def initialize(pivot : Position, width : Int32, height : Int32)
       initialize(pivot, width, height, "normal")
     end
 
     # Border based on a single character
-    def initialize(pivot : Position, width : Int, height : Int, char : Char)
+    def initialize(pivot : Position, width : Int32, height : Int32, char : Char)
       initialize(pivot, width, height, "char", char)
     end
 
     # Master internal constructor
-    private def initialize(@pivot : Position, @width : Int, @height : Int, @mode : String, @char : Char)
+    private def initialize(@pivot : Position, @width : Int32, @height : Int32, @mode : String, @char : Char)
       @foreground = COLOR_NIL
       @background = COLOR_NIL
     end

--- a/src/termbox/cell.cr
+++ b/src/termbox/cell.cr
@@ -6,7 +6,7 @@ module Termbox
     getter :position, :char, :foreground, :background
 
     # Make a cell with a specified foreground and background
-    def initialize(@char : Char, @position : Position, @foreground : Int, @background : Int)
+    def initialize(@char : Char, @position : Position, @foreground : UInt16, @background : UInt16)
     end
 
     # Make a cell with default colors
@@ -15,7 +15,7 @@ module Termbox
     end
 
     # Make a new cell with a position transformed by x and y
-    def new_transform(x : Int, y : Int)
+    def new_transform(x : Int32, y : Int32)
       Cell.new(@char, @position.new_transform(x, y), @foreground, @background)
     end
 

--- a/src/termbox/constants.cr
+++ b/src/termbox/constants.cr
@@ -80,16 +80,16 @@ module Termbox
   MOD_ALT = 0x01
 
   # Colors
-  COLOR_NIL     = -1
-  COLOR_DEFAULT = 0x00
-  COLOR_BLACK   = 0x01
-  COLOR_RED     = 0x02
-  COLOR_GREEN   = 0x03
-  COLOR_YELLOW  = 0x04
-  COLOR_BLUE    = 0x05
-  COLOR_MAGENTA = 0x06
-  COLOR_CYAN    = 0x07
-  COLOR_WHITE   = 0x08
+  COLOR_NIL     = 0xffff_u16
+  COLOR_DEFAULT = 0x00_u16
+  COLOR_BLACK   = 0x01_u16
+  COLOR_RED     = 0x02_u16
+  COLOR_GREEN   = 0x03_u16
+  COLOR_YELLOW  = 0x04_u16
+  COLOR_BLUE    = 0x05_u16
+  COLOR_MAGENTA = 0x06_u16
+  COLOR_CYAN    = 0x07_u16
+  COLOR_WHITE   = 0x08_u16
 
   # Attributes
   ATTR_BOLD      = 0x0100

--- a/src/termbox/container.cr
+++ b/src/termbox/container.cr
@@ -7,7 +7,7 @@ module Termbox
     getter :elements
 
     # Accepts a pivot (top left position), width, and height
-    def initialize(@pivot : Position, @width : Int, @height : Int)
+    def initialize(@pivot : Position, @width : Int32, @height : Int32)
       @elements = [] of Element
     end
 

--- a/src/termbox/line.cr
+++ b/src/termbox/line.cr
@@ -4,7 +4,7 @@ module Termbox
   class Line < Termbox::Element
     getter :cell, :size, :is_vertical
 
-    def initialize(@cell : Cell, @size : Int, @is_vertical : Bool = true)
+    def initialize(@cell : Cell, @size : Int32, @is_vertical : Bool = true)
     end
 
     def render : Array(Cell)

--- a/src/termbox/position.cr
+++ b/src/termbox/position.cr
@@ -3,10 +3,10 @@ module Termbox
   struct Position
     getter :x, :y
 
-    def initialize(@x : Int, @y : Int)
+    def initialize(@x : Int32, @y : Int32)
     end
 
-    def new_transform(x : Int, y : Int)
+    def new_transform(x : Int32, y : Int32)
       Position.new(@x + x, @y + y)
     end
   end

--- a/src/termbox/window.cr
+++ b/src/termbox/window.cr
@@ -106,7 +106,7 @@ module Termbox
     end
 
     # Put a decomposed cell and decomposed position, bypassing @elements store
-    private def put_raw(x : Int, y : Int, ch : Int, foreground : Int, background : Int) : Void
+    private def put_raw(x : Int, y : Int, ch : Int, foreground : UInt16, background : UInt16) : Void
       TermboxBindings.tb_change_cell(x, y, ch, foreground, background)
     end
 
@@ -126,7 +126,7 @@ module Termbox
     end
 
     # Set primary colors
-    def set_primary_colors(foreground : Int, background : Int) : Void
+    def set_primary_colors(foreground : UInt16, background : UInt16) : Void
       @foreground = foreground
       @background = background
       TermboxBindings.tb_set_clear_attributes(foreground, background)


### PR DESCRIPTION
Using `Int` for instance variable types is invalid in the latest Crystal.